### PR TITLE
Changed validation type to be strict after discovering initial test .…

### DIFF
--- a/tools/gatk_variantannotator.cwl
+++ b/tools/gatk_variantannotator.cwl
@@ -23,7 +23,7 @@ arguments:
       -V $(inputs.cgp_filtered_vcf.path)
       -A PossibleDeNovo
       -ped $(inputs.ped.path)
-      --pedigreeValidationType SILENT
+      --pedigreeValidationType STRICT
 
 inputs:
   reference: {type: File, secondaryFiles: [^.dict, .fai]}


### PR DESCRIPTION
…ped files were missing two lines.  Functionally should be 0 difference, but good to make the change for consistency and accuracy across pipelines in terms of params and inputs.